### PR TITLE
Fix control input at initial condition in distillation model

### DIFF
--- a/var_elim/models/distillation/distill.py
+++ b/var_elim/models/distillation/distill.py
@@ -185,7 +185,7 @@ def create_instance(horizon=52, vol=1.6, x_Feed=0.5, nfe=50):
     discretize_model(instance, nfe=nfe)
 
     # Fix control variable at initial condition. For backward difference,
-    # it does not effect the rest of the model, and does not participate
+    # it does not affect the rest of the model, and does not participate
     # in the objective, so it has an undefined solution.
     instance.u1[1].fix()
 


### PR DESCRIPTION
We have the following independent subsystem of variables and constraints at the initial conditions: 
```console
'u1[1]'                                                                                                                        
'rr[1]'                                                                                                                        
'L[1]'                                                                                                                         
'V[1]'                                                                                                                         
'FL[1]'                                                                                                                        
'reflux_ratio[1]'                                                                                                                                                                                                                                    
'flowrate_rectification[1]'                                                                                                    
'vapor_column[1]'                                                                                                              
'flowrate_stripping[1]'                                                                                                        
```
None of these variables appear elsewhere in the model. This (a) leads to an undefined solution for these 5 variables and (b) allows us to eliminate 5 variables with these 4 constraints, leading to confusing variable counts. I've fixed `u1[1]` to prevent this.