### PR TITLE
Disable named expressions for MB+LD2

### DIFF
--- a/var_elim/algorithms/validate.py
+++ b/var_elim/algorithms/validate.py
@@ -24,6 +24,30 @@ from pyomo.core.base.var import Var
 from idaes.core.util.model_statistics import large_residuals_set
 
 
+def _violates_relative_constraint_tolerance(con, tolerance):
+    body_value = pyo_value(con.body)
+
+    if con.upper is not None:
+        upper = pyo_value(con.upper)
+        upper_diff = body_value - upper
+        if upper_diff > tolerance:
+            relative_upper_diff = (
+                upper_diff / abs(upper) if upper != 0 else upper_diff
+            )
+            return relative_upper_diff > tolerance
+
+    if con.lower is not None:
+        lower = pyo_value(con.lower)
+        lower_diff = lower - body_value
+        if lower_diff > tolerance:
+            relative_lower_diff = (
+                lower_diff / abs(lower) if lower != 0 else lower_diff
+            )
+            return relative_lower_diff > tolerance
+
+    return False
+
+
 def validate_solution(
     model,
     eliminated_var_exprs,
@@ -33,7 +57,11 @@ def validate_solution(
     violated_cons_reduced = large_residuals_set(
         model, tol=tolerance, return_residual_values=True
     )
-    violated_cons_reduced = list(violated_cons_reduced.items())
+    violated_cons_reduced = [
+        (con, resid)
+        for con, resid in violated_cons_reduced.items()
+        if _violates_relative_constraint_tolerance(con, tolerance)
+    ]
 
     # Set variables to value defined by elimination expression
     # We assume these expressions are in terms of reduced-space variables.

--- a/var_elim/algorithms/validate.py
+++ b/var_elim/algorithms/validate.py
@@ -46,12 +46,16 @@ def validate_solution(
             continue
         if var.ub is not None:
             ub_diff = pyo_value(var.value - var.ub)
-            if ub_diff > tolerance:
-                vars_violating_bounds.append((var, var.ub, ub_diff))
+            # We allow a large(r) bound violation if the relative tolerance is small.
+            # This occurs for pipeline models for bounds with magnitude 1e3-1e4
+            relative_ub_diff = ub_diff / abs(var.ub) if var.ub != 0 else ub_diff
+            if ub_diff > tolerance and relative_ub_diff > tolerance:
+                vars_violating_bounds.append((var, var.ub, max(ub_diff, relative_ub_diff)))
         if var.lb is not None:
             lb_diff = pyo_value(var.value - var.lb)
-            if lb_diff < - tolerance:
-                vars_violating_bounds.append((var, var.lb, lb_diff))
+            relative_lb_diff = lb_diff / abs(var.lb) if var.lb != 0 else lb_diff
+            if lb_diff < - tolerance and relative_lb_diff < - tolerance:
+                vars_violating_bounds.append((var, var.lb, min(lb_diff, relative_lb_diff)))
 
     violated_eliminated_cons = []
     for con in eliminated_constraints:

--- a/var_elim/algorithms/validate.py
+++ b/var_elim/algorithms/validate.py
@@ -50,12 +50,12 @@ def validate_solution(
             # This occurs for pipeline models for bounds with magnitude 1e3-1e4
             relative_ub_diff = ub_diff / abs(var.ub) if var.ub != 0 else ub_diff
             if ub_diff > tolerance and relative_ub_diff > tolerance:
-                vars_violating_bounds.append((var, var.ub, max(ub_diff, relative_ub_diff)))
+                vars_violating_bounds.append((var, var.ub, min(ub_diff, relative_ub_diff)))
         if var.lb is not None:
             lb_diff = pyo_value(var.value - var.lb)
             relative_lb_diff = lb_diff / abs(var.lb) if var.lb != 0 else lb_diff
             if lb_diff < - tolerance and relative_lb_diff < - tolerance:
-                vars_violating_bounds.append((var, var.lb, min(lb_diff, relative_lb_diff)))
+                vars_violating_bounds.append((var, var.lb, max(lb_diff, relative_lb_diff)))
 
     violated_eliminated_cons = []
     for con in eliminated_constraints:

--- a/var_elim/elimination_callbacks.py
+++ b/var_elim/elimination_callbacks.py
@@ -65,10 +65,6 @@ StructuralResults = namedtuple(
 )
 
 
-# TODO: Command line argument
-USE_NAMED_EXPRESSIONS = True
-
-
 def get_equality_constraints(model):
     eq_cons = []
     for con in model.component_data_objects(pyo.Constraint, active=True):
@@ -81,6 +77,7 @@ def matching_elim_callback(model, **kwds):
     timer = kwds.pop("timer", HierarchicalTimer())
     # In case we don't want to modify the model in-place
     eliminate = kwds.pop("eliminate", True)
+    use_named_expressions = kwds.pop("use_named_expressions", True)
 
     igraph = kwds.pop("igraph", None)
     linear_igraph = kwds.pop("linear_igraph", None)
@@ -166,7 +163,7 @@ def matching_elim_callback(model, **kwds):
             var_elim,
             con_elim,
             igraph=igraph,
-            use_named_expressions=USE_NAMED_EXPRESSIONS,
+            use_named_expressions=use_named_expressions,
             timer=timer,
         )
     else:
@@ -181,6 +178,7 @@ def linear_degree1_elim_callback(model, **kwds):
     igraph = kwds.pop("igraph", None)
     linear_igraph = kwds.pop("linear_igraph", None)
     timer = kwds.pop("timer", HierarchicalTimer())
+    use_named_expressions = kwds.pop("use_named_expressions", True)
 
     if igraph is None:
         timer.start("igraph")
@@ -223,7 +221,7 @@ def linear_degree1_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             # We need to perform the elimination on the linear and equality-only
@@ -249,6 +247,7 @@ def degree2_elim_callback(model, **kwds):
     igraph = kwds.pop("igraph", None)
     linear_igraph = kwds.pop("linear_igraph", None)
     timer = kwds.pop("timer", HierarchicalTimer())
+    use_named_expressions = kwds.pop("use_named_expressions", True)
 
     if igraph is None:
         timer.start("igraph")
@@ -292,7 +291,7 @@ def degree2_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             timer.start("eliminate-nodes")
@@ -321,7 +320,7 @@ def degree2_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             timer.start("eliminate-nodes")
@@ -342,6 +341,7 @@ def equalcoef_degree2_elim_callback(model, **kwds):
     igraph = kwds.pop("igraph", None)
     linear_igraph = kwds.pop("linear_igraph", None)
     timer = kwds.pop("timer", HierarchicalTimer())
+    use_named_expressions = kwds.pop("use_named_expressions", True)
 
     if igraph is None:
         timer.start("igraph")
@@ -383,7 +383,7 @@ def equalcoef_degree2_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             timer.start("eliminate-nodes")
@@ -413,7 +413,7 @@ def equalcoef_degree2_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             timer.start("eliminate-nodes")
@@ -434,6 +434,7 @@ def linear_degree2_elim_callback(model, **kwds):
     igraph = kwds.pop("igraph", None)
     linear_igraph = kwds.pop("linear_igraph", None)
     timer = kwds.pop("timer", HierarchicalTimer())
+    use_named_expressions = kwds.pop("use_named_expressions", True)
     if igraph is None:
         timer.start("igraph")
         igraph = IncidenceGraphInterface(
@@ -474,7 +475,7 @@ def linear_degree2_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             timer.start("eliminate-nodes")
@@ -504,7 +505,7 @@ def linear_degree2_elim_callback(model, **kwds):
                 var_elim,
                 con_elim,
                 igraph=igraph,
-                use_named_expressions=USE_NAMED_EXPRESSIONS,
+                use_named_expressions=use_named_expressions,
             )
             timer.stop("eliminate")
             timer.start("eliminate-nodes")
@@ -528,6 +529,7 @@ def no_elim_callback(model, **kwds):
 def greedy_elim_callback(model, **kwds):
     igraph = kwds.pop('igraph', None)
     timer = kwds.pop("timer", HierarchicalTimer())
+    use_named_expressions = kwds.pop("use_named_expressions", True)
     if igraph is None:
         timer.start("igraph")
         igraph = IncidenceGraphInterface(
@@ -562,7 +564,7 @@ def greedy_elim_callback(model, **kwds):
             var_elim,
             con_elim,
             igraph = igraph,
-            use_named_expressions=USE_NAMED_EXPRESSIONS,
+            use_named_expressions=use_named_expressions,
         )
         timer.stop("eliminate")
     else:

--- a/var_elim/scripts/analyze_solvetime.py
+++ b/var_elim/scripts/analyze_solvetime.py
@@ -122,12 +122,19 @@ def main(args):
         htimer.start(label)
         print(mname, elim_name)
 
+        # HACK: There appears to be a .nl writer bug with MB+LD2 with named expressions.
+        if mname == "mb-steady" and elim_name == "linear-d2":
+            use_named_expressions = False
+        else:
+            use_named_expressions = True
+
         timer.tic()
         htimer.start("elimination")
         elim_res = elim_callback(
             model,
             timer=htimer,
             skip_extra_info=True,
+            use_named_expressions=use_named_expressions,
         )
         htimer.stop("elimination")
         elim_time = timer.toc("Apply elimination")

--- a/var_elim/scripts/config.py
+++ b/var_elim/scripts/config.py
@@ -171,7 +171,7 @@ def get_argparser():
             " preliminary results created with different dependency versions."
         ),
     )
-    argparser.add_argument("--feastol", type=float, default=1e-5, help="Tolerance for checking feasibility")
+    argparser.add_argument("--feastol", type=float, default=1e-4, help="Tolerance for checking feasibility")
     return argparser
 
 def get_sweep_argparser():

--- a/var_elim/scripts/run_param_sweep.py
+++ b/var_elim/scripts/run_param_sweep.py
@@ -113,6 +113,11 @@ def main(args):
             # use TimedCyIpoptSolver
             solver = pyo.SolverFactory("cyipopt", options=options)
 
+            if problem_name == "mb-steady" and elim_name == "linear-d2":
+                use_named_expressions = False
+            else:
+                use_named_expressions = True
+
             def run_model(model, solver):
                 timer = HierarchicalTimer()
                 # Optional: re-initialize
@@ -127,7 +132,7 @@ def main(args):
 
                 # Run the elimination method
                 timer.start("elimination")
-                elim_results = elim_cb(model)
+                elim_results = elim_cb(model, use_named_expressions=use_named_expressions)
                 timer.stop("elimination")
 
                 timer.start("solve")

--- a/var_elim/scripts/summarize_sweep_results.py
+++ b/var_elim/scripts/summarize_sweep_results.py
@@ -29,6 +29,28 @@ SolveResults = namedtuple(
 )
 
 
+def warn_successful_infeasible(df, model, method):
+    infeasibility_columns = ["max-infeasibility", "max_infeasibility"]
+    infeasibility_column = next(
+        (col for col in infeasibility_columns if col in df.columns),
+        None,
+    )
+    index_column = "Unnamed: 0" if "Unnamed: 0" in df.columns else None
+
+    successful_infeasible = df[(df["success"] == True) & (df["feasible"] == False)]
+    for idx, row in successful_infeasible.iterrows():
+        case_index = row[index_column] if index_column is not None else idx
+        infeasibility = (
+            row[infeasibility_column]
+            if infeasibility_column is not None
+            else "not available"
+        )
+        print(
+            f"WARNING: {model}, {method}: success=True but feasible=False at "
+            f"index {case_index}; infeasibility={infeasibility}"
+        )
+
+
 def summarize_single_model(args, elim_names):
     sweep_data = {
         "model": [],
@@ -45,6 +67,7 @@ def summarize_single_model(args, elim_names):
         fname = args.model + "-" + elimname + "-sweep" + suff_str + ".csv"
         fpath = os.path.join(args.results_dir, fname)
         df = pd.read_csv(fpath)
+        warn_successful_infeasible(df, args.model, elimname)
 
         n_success = list(df["success"]).count(True)
         n_total = len(df["success"])


### PR DESCRIPTION
There is some odd behavior for the MB+LD2 model-method combination. Here are a few lines of output from `analyze_solvetime.py`:
```console
EXIT: Optimal Solution Found.
[+   0.08] Solve model
WARNING: Constraints in the reduced-space model are violated
WARNING: Result is not valid!
[+   0.05] Validate result
```
The first line above is the last line of output from IPOPT: We converge to an optimal solution, but our post-solve constraint evaluation identifies an infeasible solution. What's unusual is that, on further inspection, the constraint violation magnitude is 0.17. This is much too large to be a difference due to scaled/unscaled models, IPOPT's bound relaxation, or any other solver-specific idiosyncrasy. I've found that this behavior only occurs when we use named expressions, so I'm patching our scripts to avoid using named expressions for this model-method combination.

I've looked into this discrepancy a bit and I think this is most likely an NL writer bug. I will open a Pyomo issue once I'm happy with this workaround.

This needs:
- [x] Comparison of runtime results
- [x] Comparison of convergence results
- [x] Controls in place so this doesn't come up again (and we're sure it isn't happening for other model-method combinations)